### PR TITLE
Implement global provider

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ description = "A Rust OpenTelemetry client"
 homepage = "https://github.com/jtescher/opentelemetry-rust"
 repository = "https://github.com/jtescher/opentelemetry-rust"
 readme = "README.md"
+categories = ["development-tools::debugging"]
 keywords = ["opentelemetry", "jaeger", "prometheus"]
 license = "MIT"
 edition = "2018"

--- a/README.md
+++ b/README.md
@@ -12,12 +12,11 @@ A Rust [OpenTelemetry](https://opentelemetry.io/) client.
 use opentelemetry::{api::{Provider, TracerGenerics}, global, sdk};
 
 fn main() {
-    let tracer = sdk::Provider::new().get_tracer("service_name");
-    global::set_tracer(Box::new(tracer));
+    global::set_provider(sdk::Provider::default());
 
-    global::global_tracer().with_span("foo", || {
-        global::global_tracer().with_span("bar", || {
-            global::global_tracer().with_span("baz", || {
+    global::trace_provider().get_tracer("component-a").with_span("foo", |_span| {
+        global::trace_provider().get_tracer("component-b").with_span("bar", |_span| {
+            global::trace_provider().get_tracer("component-c").with_span("baz", |_span| {
 
             })
         })
@@ -25,7 +24,7 @@ fn main() {
 }
 ```
 
-See the [opentelemetry-example-app](./example/basic.rs) for a complete example.
+See the [opentelemetry-example-app](./examples/basic.rs) for a complete example.
 
 ## Release Schedule
 

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -1,14 +1,34 @@
 use opentelemetry::api::{
-    Gauge, GaugeHandle, Key, Measure, MeasureHandle, Meter, MetricOptions, Provider, Span, Tracer,
+    Gauge, GaugeHandle, Key, Measure, MeasureHandle, Meter, MetricOptions, Provider, Sampler, Span,
     TracerGenerics,
 };
-use opentelemetry::{global, sdk};
+use opentelemetry::{exporter::trace::jaeger, global, sdk};
 use std::thread;
 use std::time::Duration;
 
+fn init_tracer() {
+    let exporter = jaeger::Exporter::builder()
+        .with_collector_endpoint("127.0.0.1:6831".parse().unwrap())
+        .with_process(jaeger::Process {
+            service_name: "trace-demo",
+            tags: vec![
+                Key::new("exporter").string("jaeger"),
+                Key::new("float").f64(312.23),
+            ],
+        })
+        .init();
+    let provider = sdk::Provider::builder()
+        .with_exporter(exporter)
+        .with_config(sdk::Config {
+            default_sampler: Sampler::Always,
+            ..Default::default()
+        })
+        .build();
+    global::set_provider(provider);
+}
+
 fn main() {
-    let tracer = sdk::Provider::new().get_tracer("ex_com_basic");
-    global::set_tracer(Box::new(tracer));
+    init_tracer();
     let meter = sdk::Meter::new("ex_com_basic");
 
     let lemons_key = Key::new("ex_com_lemons");
@@ -32,27 +52,29 @@ fn main() {
 
     let measure = measure_two.acquire_handle(&common_labels);
 
-    global::global_tracer().with_span("operation", move || {
-        let mut span = global::global_tracer().get_active_span();
-        span.add_event("Nice operation!".to_string());
-        span.set_attribute(another_key.string("yes"));
+    global::trace_provider()
+        .get_tracer("component-main")
+        .with_span("operation", move |span| {
+            span.add_event("Nice operation!".to_string());
+            span.set_attribute(another_key.string("yes"));
 
-        gauge.set(1.0);
+            gauge.set(1.0);
 
-        meter.record_batch(
-            &common_labels,
-            vec![one_metric.measurement(1.0), measure_two.measurement(2.0)],
-        );
+            meter.record_batch(
+                &common_labels,
+                vec![one_metric.measurement(1.0), measure_two.measurement(2.0)],
+            );
 
-        global::global_tracer().with_span("Sub operation...", move || {
-            let mut span = global::global_tracer().get_active_span();
-            span.set_attribute(lemons_key.string("five"));
+            global::trace_provider()
+                .get_tracer("component-bar")
+                .with_span("Sub operation...", move |span| {
+                    span.set_attribute(lemons_key.string("five"));
 
-            span.add_event("Sub span event".to_string());
+                    span.add_event("Sub span event".to_string());
 
-            measure.record(1.3);
+                    measure.record(1.3);
+                });
         });
-    });
 
     // Allow flush
     thread::sleep(Duration::from_millis(250));

--- a/examples/report.rs
+++ b/examples/report.rs
@@ -8,7 +8,7 @@ use std::thread;
 use std::time::Duration;
 
 fn main() {
-    let tracer = sdk::Provider::new().get_tracer("report_example");
+    let tracer = sdk::Provider::default().get_tracer("report_example");
     {
         let span0 = tracer.start("main", None);
         thread::sleep(Duration::from_millis(10));

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -32,6 +32,7 @@ pub use trace::{
     noop::{NoopProvider, NoopSpan, NoopTracer},
     propagator::{BinaryFormat, Carrier, HttpTextFormat},
     provider::Provider,
+    sampler::Sampler,
     span::Span,
     span_context::{SpanContext, TRACE_FLAGS_UNUSED, TRACE_FLAG_SAMPLED},
     tracer::{Tracer, TracerGenerics},

--- a/src/api/trace/mod.rs
+++ b/src/api/trace/mod.rs
@@ -94,6 +94,7 @@
 pub mod noop;
 pub mod propagator;
 pub mod provider;
+pub mod sampler;
 pub mod span;
 pub mod span_context;
 pub mod tracer;

--- a/src/api/trace/provider.rs
+++ b/src/api/trace/provider.rs
@@ -22,7 +22,7 @@
 use crate::api;
 
 /// An interface to create `Tracer` instances.
-pub trait Provider {
+pub trait Provider: Send + Sync {
     /// The `Tracer` type that this `Provider` will return.
     type Tracer: api::Tracer;
 

--- a/src/api/trace/sampler.rs
+++ b/src/api/trace/sampler.rs
@@ -1,0 +1,15 @@
+//! # OpenTelemetry Sampler Interface
+
+/// Sampling options
+#[derive(Debug)]
+pub enum Sampler {
+    /// Always sample the trace
+    Always,
+    /// Never sample the trace
+    Never,
+    /// Sample a given fraction of traces. Fractions >= 1 will always sample.
+    /// If the parent span is sampled, then it's child spans will automatically
+    /// be sampled. Fractions <0 are treated as zero, but spans may still be
+    /// sampled if their parent is.
+    Probability(f64),
+}

--- a/src/exporter/metrics/prometheus/mod.rs
+++ b/src/exporter/metrics/prometheus/mod.rs
@@ -46,7 +46,7 @@ impl api::Counter<i64, sdk::LabelSet> for prometheus::IntCounterVec {
         api::Measurement::new(Arc::new(self.clone()), api::MeasurementValue::from(value))
     }
 
-    /// Creates a handle for this instrument..
+    /// Creates a handle for this instrument.
     fn acquire_handle(&self, labels: &sdk::LabelSet) -> Self::Handle {
         IntCounterHandle(self.with(&convert_label_set(labels)))
     }
@@ -82,7 +82,7 @@ impl api::Counter<f64, sdk::LabelSet> for prometheus::CounterVec {
         api::Measurement::new(Arc::new(self.clone()), api::MeasurementValue::from(value))
     }
 
-    /// Creates a handle for this instrument..
+    /// Creates a handle for this instrument.
     fn acquire_handle(&self, labels: &sdk::LabelSet) -> Self::Handle {
         CounterHandle(self.with(&convert_label_set(labels)))
     }
@@ -120,7 +120,7 @@ impl api::Gauge<i64, sdk::LabelSet> for prometheus::IntGaugeVec {
         api::Measurement::new(Arc::new(self.clone()), api::MeasurementValue::from(value))
     }
 
-    /// Creates a handle for this instrument..
+    /// Creates a handle for this instrument.
     fn acquire_handle(&self, labels: &sdk::LabelSet) -> Self::Handle {
         IntGaugeHandle(self.with(&convert_label_set(labels)))
     }
@@ -156,7 +156,7 @@ impl api::Gauge<f64, sdk::LabelSet> for prometheus::GaugeVec {
         api::Measurement::new(Arc::new(self.clone()), api::MeasurementValue::from(value))
     }
 
-    /// Creates a handle for this instrument..
+    /// Creates a handle for this instrument.
     fn acquire_handle(&self, labels: &sdk::LabelSet) -> Self::Handle {
         GaugeHandle(self.with(&convert_label_set(labels)))
     }
@@ -206,7 +206,7 @@ impl api::Measure<i64, sdk::LabelSet> for IntMeasure {
         api::Measurement::new(Arc::new(self.clone()), api::MeasurementValue::from(value))
     }
 
-    /// Creates a handle for this instrument..
+    /// Creates a handle for this instrument.
     fn acquire_handle(&self, labels: &sdk::LabelSet) -> Self::Handle {
         IntMeasureHandle(self.0.with(&convert_label_set(labels)))
     }
@@ -243,7 +243,7 @@ impl api::Measure<f64, sdk::LabelSet> for prometheus::HistogramVec {
         api::Measurement::new(Arc::new(self.clone()), api::MeasurementValue::from(value))
     }
 
-    /// Creates a handle for this instrument..
+    /// Creates a handle for this instrument.
     fn acquire_handle(&self, labels: &sdk::LabelSet) -> Self::Handle {
         MeasureHandle(self.with(&convert_label_set(labels)))
     }

--- a/src/exporter/trace/jaeger.rs
+++ b/src/exporter/trace/jaeger.rs
@@ -5,14 +5,154 @@
 //!
 //! [rustracing_jaeger library]: https://github.com/sile/rustracing_jaeger
 //! [OpenTracing API]: https://opentracing.io/
-use crate::api;
+use crate::exporter::trace;
+use crate::{api, sdk};
+use std::any;
+use std::net;
 use std::str::FromStr;
+use std::thread;
 
 pub use rustracing::{
-    sampler::{AllSampler, NullSampler, ProbabilisticSampler, Sampler},
+    sampler::{AllSampler, NullSampler, ProbabilisticSampler},
     tag::{Tag, TagValue},
 };
-pub use rustracing_jaeger::{reporter::JaegerCompactReporter, span::SpanContext, Span, Tracer};
+pub use rustracing_jaeger::{
+    reporter,
+    span::{SpanContext, SpanSender},
+    Span, Tracer,
+};
+
+/// Default service name no service is configured.
+static DEFAULT_SERVICE_NAME: &str = "OpenTelemetry";
+static DEFAULT_COLLECTOR_ENDPOINT: &str = "127.0.0.1:6831";
+
+/// Jaeger exporter
+#[derive(Debug)]
+pub struct Exporter {
+    collector_endpoint: net::SocketAddr,
+    process: Process,
+    pub(crate) span_sender: SpanSender,
+}
+
+impl Exporter {
+    /// Create a new exporter builder.
+    pub fn builder() -> Builder {
+        Builder::default()
+    }
+
+    /// Default `Exporter` with initialized sender.
+    pub fn init_default() -> Self {
+        Exporter::builder().init()
+    }
+}
+
+impl trace::SpanExporter for Exporter {
+    type Span = sdk::Span;
+
+    /// Ignored because spans export themselves on drop currently.
+    fn export(&self, _batch: Vec<Self::Span>) -> Result<(), ()> {
+        Ok(())
+    }
+
+    /// Ignored for now.
+    fn shutdown(&self) {}
+
+    /// Allows `Exporter` to be downcast from trait object.
+    fn as_any(&self) -> &dyn any::Any {
+        self
+    }
+}
+
+/// Jaeger process configuration
+#[derive(Debug)]
+pub struct Process {
+    /// The name of the traced service that all spans will be reported as belonging to.
+    pub service_name: &'static str,
+    /// Metadata about the service that will appear in all `Span`s.
+    pub tags: Vec<api::KeyValue>,
+}
+
+impl Default for Process {
+    /// Default `Process` config
+    fn default() -> Self {
+        Process {
+            service_name: DEFAULT_SERVICE_NAME,
+            tags: Default::default(),
+        }
+    }
+}
+
+/// Jaeger Exporter Builder
+#[derive(Debug)]
+pub struct Builder {
+    collector_endpoint: net::SocketAddr,
+    process: Process,
+}
+
+impl Default for Builder {
+    fn default() -> Self {
+        Builder {
+            collector_endpoint: DEFAULT_COLLECTOR_ENDPOINT.parse().unwrap(),
+            process: Default::default(),
+        }
+    }
+}
+
+impl Builder {
+    /// Assign the collector endpoint. Uses `DEFAULT_COLLECTOR_ENDPOINT` if unset.
+    pub fn with_collector_endpoint(self, collector_endpoint: net::SocketAddr) -> Self {
+        Builder {
+            collector_endpoint,
+            ..self
+        }
+    }
+
+    /// Assign the exporter process config.
+    pub fn with_process(self, process: Process) -> Self {
+        Builder { process, ..self }
+    }
+
+    /// Create a new exporter from the builder
+    pub fn init(self) -> Exporter {
+        let Builder {
+            collector_endpoint,
+            process: Process { service_name, tags },
+        } = self;
+        let reporter_tags = tags.clone();
+        let (span_tx, span_rx) = crossbeam_channel::bounded(10);
+
+        // Spin up thread to report finished spans
+        let _ = thread::Builder::new()
+            .name("Jaeger span reporter".to_string())
+            .spawn(move || {
+                let mut reporter = reporter::JaegerCompactReporter::new(service_name)
+                    .expect("Can't initialize jaeger reporter");
+
+                reporter
+                    .set_agent_addr(collector_endpoint)
+                    .expect("Can't set socket jaeger reporter socket");
+                for tag in reporter_tags {
+                    let api::KeyValue { key, value } = tag;
+                    let value = match value {
+                        api::Value::Bool(b) => TagValue::Boolean(b),
+                        api::Value::I64(i) => TagValue::Integer(i),
+                        api::Value::F64(float) => TagValue::Float(float),
+                        v => TagValue::String(v.into()),
+                    };
+                    reporter.add_service_tag(Tag::new(key, value))
+                }
+                for span in span_rx {
+                    let _ = reporter.report(&[span]);
+                }
+            });
+
+        Exporter {
+            collector_endpoint,
+            process: Process { service_name, tags },
+            span_sender: span_tx,
+        }
+    }
+}
 
 impl From<api::SpanContext> for rustracing_jaeger::span::SpanContext {
     /// Convert from `api::SpanContext` instances to `rustracing_jaeger`'s `SpanContext` type.

--- a/src/exporter/trace/mod.rs
+++ b/src/exporter/trace/mod.rs
@@ -1,2 +1,47 @@
 //! Trace exporters
+use crate::api;
+
 pub mod jaeger;
+
+/// `SpanExporter` defines the interface that protocol-specific exporters must
+/// implement so that they can be plugged into OpenTelemetry SDK and support
+/// sending of telemetry data.
+///
+/// The goals of the interface are:
+///
+/// - Minimize burden of implementation for protocol-dependent telemetry
+///  exporters. The protocol exporter is expected to be primarily a simple
+/// telemetry data encoder and transmitter.
+/// - Allow implementing helpers as composable components that use the same
+/// chainable Exporter interface. SDK authors are encouraged to implement common
+/// functionality such as queuing, batching, tagging, etc. as helpers. This
+/// functionality will be applicable regardless of what protocol exporter is used.
+pub trait SpanExporter: Send + Sync + std::fmt::Debug {
+    /// The type of `Span` that is exported
+    type Span: api::Span;
+    /// Exports a batch of telemetry data. Protocol exporters that will implement
+    /// this function are typically expected to serialize and transmit the data
+    /// to the destination.
+    ///
+    /// This function will never be called concurrently for the same exporter
+    /// instance. It can be called again only after the current call returns.
+    ///
+    /// This function must not block indefinitely, there must be a reasonable
+    /// upper limit after which the call must time out with an error result.
+    fn export(&self, batch: Vec<Self::Span>) -> Result<(), ()>;
+
+    /// Shuts down the exporter. Called when SDK is shut down. This is an
+    /// opportunity for exporter to do any cleanup required.
+    ///
+    /// `shutdown` should be called only once for each Exporter instance. After
+    /// the call to `shutdown`, subsequent calls to `SpanExport` are not allowed
+    /// and should return an error.
+    ///
+    /// Shutdown should not block indefinitely (e.g. if it attempts to flush the
+    /// data and the destination is unavailable). SDK authors can
+    /// decide if they want to make the shutdown timeout to be configurable.
+    fn shutdown(&self);
+
+    /// Allows exporter to be downcast
+    fn as_any(&self) -> &dyn std::any::Any;
+}

--- a/src/sdk/mod.rs
+++ b/src/sdk/mod.rs
@@ -9,5 +9,6 @@
 pub mod metrics;
 pub mod trace;
 
+pub use crate::exporter::trace::jaeger::AllSampler as AlwaysSample;
 pub use metrics::{LabelSet, Meter};
-pub use trace::{provider::Provider, span::Span, tracer::Tracer};
+pub use trace::{config::Config, provider::Provider, span::Span, tracer::Tracer};

--- a/src/sdk/trace/config.rs
+++ b/src/sdk/trace/config.rs
@@ -1,0 +1,30 @@
+//! SDK Configuration
+//!
+//! Configuration represents the global tracing configuration, overrides
+//! can be set for the default OpenTelemetry limits and Sampler.
+use crate::api;
+
+/// Tracer configuration
+#[derive(Debug)]
+pub struct Config {
+    /// The sampler that the sdk should use
+    pub default_sampler: api::Sampler,
+    /// The max events that can be added to a `Span`.
+    pub max_events_per_span: u32,
+    /// The max attributes that can be added to a `Span`.
+    pub max_attributes_per_span: u32,
+    /// The max links that can be added to a `Span`.
+    pub max_links_per_span: u32,
+}
+
+impl Default for Config {
+    /// Create default global sdk configuration.
+    fn default() -> Self {
+        Config {
+            default_sampler: api::Sampler::Always,
+            max_events_per_span: 128,
+            max_attributes_per_span: 32,
+            max_links_per_span: 32,
+        }
+    }
+}

--- a/src/sdk/trace/mod.rs
+++ b/src/sdk/trace/mod.rs
@@ -6,6 +6,7 @@
 //! * The `Span` struct with is a mutable object storing information about the
 //! current operation execution.
 //! * The `Provider` struct which configures and produces `Tracer`s.
+pub mod config;
 pub mod provider;
 pub mod span;
 pub mod tracer;

--- a/src/sdk/trace/tracer.rs
+++ b/src/sdk/trace/tracer.rs
@@ -16,13 +16,14 @@ use std::collections::HashSet;
 /// `Tracer` implementation to create and manage spans
 #[derive(Clone, Debug)]
 pub struct Tracer {
+    name: &'static str,
     inner: jaeger::Tracer,
 }
 
 impl Tracer {
     /// Create a new tracer (used internally by `Provider`s.
-    pub(crate) fn new(inner: jaeger::Tracer) -> Self {
-        Tracer { inner }
+    pub(crate) fn new(name: &'static str, inner: jaeger::Tracer) -> Self {
+        Tracer { name, inner }
     }
 }
 
@@ -49,7 +50,7 @@ impl api::Tracer for Tracer {
     /// trace includes a single root span, which is the shared ancestor of all other
     /// spans in the trace.
     fn start(&self, name: &'static str, parent_span: Option<api::SpanContext>) -> Self::Span {
-        let start_options = self.inner.span(name);
+        let start_options = self.inner.span(format!("{}/{}", self.name, name));
         let started = match parent_span.map(jaeger::SpanContext::from) {
             Some(span_context) => start_options.child_of(&span_context).start(),
             None => start_options.start(),


### PR DESCRIPTION
Switches from global `Tracer` to global `Provider` which can get tracers per component.

Resolves #8 
Resolves #5 