### PR TITLE
Allow non-static lifetimes for span names

### DIFF
--- a/src/api/trace/propagator.rs
+++ b/src/api/trace/propagator.rs
@@ -179,15 +179,15 @@ pub trait HttpTextFormat {
 /// underlying struct like `HashMap`.
 pub trait Carrier {
     /// Get a value for a key from the underlying data.
-    fn get(&self, key: &'static str) -> Option<&String>;
+    fn get(&self, key: &'static str) -> Option<&str>;
     /// Add a key and value to the underlying.
     fn set(&mut self, key: &'static str, value: String);
 }
 
 impl<S: std::hash::BuildHasher> api::Carrier for HashMap<&'static str, String, S> {
     /// Get a value for a key from the HashMap.
-    fn get(&self, key: &'static str) -> Option<&String> {
-        self.get(key)
+    fn get(&self, key: &'static str) -> Option<&str> {
+        self.get(key).map(|v| v.as_str())
     }
 
     /// Set a key and value in the HashMap.

--- a/src/api/trace/tracer.rs
+++ b/src/api/trace/tracer.rs
@@ -55,7 +55,7 @@ pub trait Tracer: Send + Sync {
     /// created in another process. Each propagators' deserialization must set
     /// `is_remote` to true on a parent `SpanContext` so `Span` creation knows if the
     /// parent is remote.
-    fn start(&self, name: &'static str, parent_span: Option<api::SpanContext>) -> Self::Span;
+    fn start(&self, name: &str, parent_span: Option<api::SpanContext>) -> Self::Span;
 
     /// Returns the current active span.
     ///

--- a/src/global.rs
+++ b/src/global.rs
@@ -63,11 +63,7 @@ pub trait GenericTracer: Send + Sync {
 
     /// Returns a trait object so the underlying implementation can be swapped
     /// out at runtime.
-    fn start_boxed(
-        &self,
-        name: &'static str,
-        parent: Option<api::SpanContext>,
-    ) -> Box<dyn api::Span>;
+    fn start_boxed(&self, name: &str, parent: Option<api::SpanContext>) -> Box<dyn api::Span>;
 
     /// Returns the currently active span as a BoxedSpan
     fn get_active_span_boxed(&self) -> Box<dyn api::Span>;
@@ -87,11 +83,7 @@ impl<S: api::Span + 'static> GenericTracer for Box<dyn api::Tracer<Span = S>> {
 
     /// Returns a trait object so the underlying implementation can be swapped
     /// out at runtime.
-    fn start_boxed(
-        &self,
-        name: &'static str,
-        parent: Option<api::SpanContext>,
-    ) -> Box<dyn api::Span> {
+    fn start_boxed(&self, name: &str, parent: Option<api::SpanContext>) -> Box<dyn api::Span> {
         Box::new(self.start(name, parent))
     }
 
@@ -123,7 +115,7 @@ impl Tracer for dyn GenericTracer {
     }
 
     /// Starts a new boxed span.
-    fn start(&self, name: &'static str, parent_span: Option<api::SpanContext>) -> Self::Span {
+    fn start(&self, name: &str, parent_span: Option<api::SpanContext>) -> Self::Span {
         BoxedSpan(self.start_boxed(name, parent_span))
     }
 
@@ -159,7 +151,7 @@ impl api::Tracer for BoxedTracer {
     }
 
     /// Starts a new `Span`.
-    fn start(&self, name: &'static str, parent_span: Option<api::SpanContext>) -> Self::Span {
+    fn start(&self, name: &str, parent_span: Option<api::SpanContext>) -> Self::Span {
         self.0.start(name, parent_span)
     }
 

--- a/src/sdk/trace/tracer.rs
+++ b/src/sdk/trace/tracer.rs
@@ -49,9 +49,12 @@ impl api::Tracer for Tracer {
     /// trace. A span is said to be a _root span_ if it does not have a parent. Each
     /// trace includes a single root span, which is the shared ancestor of all other
     /// spans in the trace.
-    fn start(&self, name: &'static str, parent_span: Option<api::SpanContext>) -> Self::Span {
+    fn start(&self, name: &str, parent_span: Option<api::SpanContext>) -> Self::Span {
         let start_options = self.inner.span(format!("{}/{}", self.name, name));
-        let started = match parent_span.map(jaeger::SpanContext::from) {
+        let started = match parent_span
+            .filter(|ctx| ctx.is_valid())
+            .map(jaeger::SpanContext::from)
+        {
             Some(span_context) => start_options.child_of(&span_context).start(),
             None => start_options.start(),
         };


### PR DESCRIPTION
* Relax lifetime constraints on span names.
* Only create from parent if it is a valid context
