### PR TITLE
Fix sdk tracer default span id

### DIFF
--- a/src/api/core.rs
+++ b/src/api/core.rs
@@ -150,8 +150,15 @@ pub struct KeyValue {
 
 impl KeyValue {
     /// Create a new `KeyValue` pair.
-    pub fn new<K, V>(key: K, value: V) -> Self where K: Into<Key>, V: Into<Value> {
-        KeyValue { key: key.into(), value: value.into() }
+    pub fn new<K, V>(key: K, value: V) -> Self
+    where
+        K: Into<Key>,
+        V: Into<Value>,
+    {
+        KeyValue {
+            key: key.into(),
+            value: value.into(),
+        }
     }
 }
 

--- a/src/sdk/trace/tracer.rs
+++ b/src/sdk/trace/tracer.rs
@@ -58,7 +58,10 @@ impl api::Tracer for Tracer {
             Some(span_context) => start_options.child_of(&span_context).start(),
             None => start_options.start(),
         };
-        let span_id = started.context().unwrap().state().span_id();
+        let span_id = started
+            .context()
+            .map(|ctx| ctx.state().span_id())
+            .unwrap_or(0);
 
         sdk::Span::new(span_id, started)
     }


### PR DESCRIPTION
Span context can be `None` when the span is a child of an unsampled span. This patch defaults the resulting span's id to the default (and invalid) `0` value.