### PR TITLE
Add `Parent` option for default sampler

### DIFF
--- a/src/api/trace/sampler.rs
+++ b/src/api/trace/sampler.rs
@@ -7,6 +7,8 @@ pub enum Sampler {
     Always,
     /// Never sample the trace
     Never,
+    /// Sample if the parent span is sampled
+    Parent,
     /// Sample a given fraction of traces. Fractions >= 1 will always sample.
     /// If the parent span is sampled, then it's child spans will automatically
     /// be sampled. Fractions <0 are treated as zero, but spans may still be

--- a/src/exporter/trace/jaeger.rs
+++ b/src/exporter/trace/jaeger.rs
@@ -13,7 +13,7 @@ use std::str::FromStr;
 use std::thread;
 
 pub use rustracing::{
-    sampler::{AllSampler, NullSampler, ProbabilisticSampler},
+    sampler::{AllSampler, NullSampler, PassiveSampler, ProbabilisticSampler},
     tag::{Tag, TagValue},
 };
 pub use rustracing_jaeger::{

--- a/src/sdk/trace/provider.rs
+++ b/src/sdk/trace/provider.rs
@@ -52,6 +52,9 @@ impl Provider {
         let tracer = match self.config.default_sampler {
             api::Sampler::Always => jaeger::Tracer::with_sender(jaeger::AllSampler, span_sender),
             api::Sampler::Never => jaeger::Tracer::with_sender(jaeger::NullSampler, span_sender),
+            api::Sampler::Parent => {
+                jaeger::Tracer::with_sender(jaeger::PassiveSampler, span_sender)
+            }
             api::Sampler::Probability(prob) => {
                 // rustracing_jaeger does not like >1 or < 0
 


### PR DESCRIPTION
This sampler will decide to trace spans if they have a parent which was sampled.

This is useful for internal components within the system that should default to upstream sampling decisions.