### PR TITLE
Prometheus API cleanup

### DIFF
--- a/src/api/core.rs
+++ b/src/api/core.rs
@@ -171,4 +171,9 @@ impl Unit {
     pub fn new<S: Into<String>>(value: S) -> Self {
         Unit(value.into())
     }
+
+    /// View unit as &str
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
 }

--- a/src/api/metrics/noop.rs
+++ b/src/api/metrics/noop.rs
@@ -8,7 +8,7 @@ use std::marker;
 use std::sync::Arc;
 
 /// A no-op instance of a `Meter`.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct NoopMeter {}
 
 impl api::Meter for NoopMeter {
@@ -102,13 +102,13 @@ impl api::Meter for NoopMeter {
 }
 
 /// A no-op instance of `LabelSet`.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct NoopLabelSet {}
 
 impl api::LabelSet for NoopLabelSet {}
 
 /// A no-op instance of all metric `InstrumentHandler`
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct NoopHandle<T> {
     _marker: marker::PhantomData<T>,
 }
@@ -126,7 +126,7 @@ impl<T> api::GaugeHandle<T> for NoopHandle<T> where T: Into<api::MeasurementValu
 impl<T> api::MeasureHandle<T> for NoopHandle<T> where T: Into<api::MeasurementValue> {}
 
 /// A no-op instance of a `Counter`.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct NoopCounter<T> {
     _marker: marker::PhantomData<T>,
 }
@@ -159,7 +159,7 @@ impl<T> api::Instrument<NoopLabelSet> for NoopCounter<T> {
 }
 
 /// A no-op instance of a `Gauge`.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct NoopGauge<T> {
     _marker: marker::PhantomData<T>,
 }
@@ -219,7 +219,7 @@ impl<T> api::Instrument<NoopLabelSet> for NoopGauge<T> {
 }
 
 /// A no-op instance of a `Measure`.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct NoopMeasure<T> {
     _marker: marker::PhantomData<T>,
 }

--- a/src/exporter/metrics/prometheus/mod.rs
+++ b/src/exporter/metrics/prometheus/mod.rs
@@ -9,8 +9,9 @@ use crate::api;
 use crate::sdk;
 use api::Key;
 pub use prometheus::{
-    default_registry, Counter, CounterVec, Encoder, Gauge, GaugeVec, Histogram, HistogramOpts,
-    HistogramVec, IntCounter, IntCounterVec, IntGauge, IntGaugeVec, Opts, Registry, TextEncoder,
+    default_registry, gather, Counter, CounterVec, Encoder, Gauge, GaugeVec, Histogram,
+    HistogramOpts, HistogramVec, IntCounter, IntCounterVec, IntGauge, IntGaugeVec, Opts, Registry,
+    TextEncoder,
 };
 use std::collections::HashMap;
 use std::sync::Arc;


### PR DESCRIPTION
This patch exposes the prometheus `gather` API, as well as implementing the `unit` option for metrics.